### PR TITLE
Update output.json

### DIFF
--- a/backend/level2/output.json
+++ b/backend/level2/output.json
@@ -6,11 +6,11 @@
     },
     {
       "id": 2,
-      "price": 6800
+      "price": 6800 #inconsistent! by readme should be 6600
     },
     {
       "id": 3,
-      "price": 27800
+      "price": 27800 #inconsistent! by readme should be 22000
     }
   ]
 }


### PR DESCRIPTION
please check that second price should apply 10% discount as written in the readme for a total amount of 6600. Here apparently is applied 5% for a total amount of 6800.
Similar is the case for the 3rd price where by the readme should be applied 50% for a total amount of 22000, but what it's provided in the file is 27800 which is 25.9 %.
What should be followed ? readme or output.json ??
