### PR TITLE
Mobile fix cars.json

### DIFF
--- a/mobile/api/cars.json
+++ b/mobile/api/cars.json
@@ -1,869 +1,920 @@
 [
-    {
-       "brand":"Citroen",
-       "model":"C3",
-       "price_per_day":17,
-       "rating":{
-          "average":4.697711,
-          "count":259
-       },
-       "owner":{
-          "name":"Elmira Sorrell",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/13.jpg",
-          "rating":{
-             "average":4.318206,
-             "count":255
-          }
+   {
+     "brand": "Citroen",
+     "model": "C3",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/13.jpg",
+     "price_per_day": 17,
+     "rating": {
+       "average": 4.697711,
+       "count": 259
+     },
+     "owner": {
+       "name": "Elmira Sorrell",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/howard.jpg",
+       "rating": {
+         "average": 4.318206,
+         "count": 255
        }
-    },
-    {
-       "brand":"Citroen",
-       "model":"Xsara Picasso",
-       "price_per_day":27,
-       "rating":{
-          "average":4.7544947,
-          "count":250
-       },
-       "owner":{
-          "name":"Britni Fitch",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/33.jpg",
-          "rating":{
-             "average":4.7478724,
-             "count":107
-          }
+     }
+   },
+   {
+     "brand": "Citroen",
+     "model": "Xsara Picasso",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/33.jpg",
+     "price_per_day": 27,
+     "rating": {
+       "average": 4.7544947,
+       "count": 250
+     },
+     "owner": {
+       "name": "Britni Fitch",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/sonia.jpg",
+       "rating": {
+         "average": 4.7478724,
+         "count": 107
        }
-    },
-    {
-       "brand":"Seat",
-       "model":"Ibiza",
-       "price_per_day":35,
-       "rating":{
-          "average":4.821972,
-          "count":55
-       },
-       "owner":{
-          "name":"Kenna Clemons",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/13.jpg",
-          "rating":{
-             "average":3.1331077,
-             "count":67
-          }
+     }
+   },
+   {
+     "brand": "Seat",
+     "model": "Ibiza",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/13.jpg",
+     "price_per_day": 35,
+     "rating": {
+       "average": 4.821972,
+       "count": 55
+     },
+     "owner": {
+       "name": "Kenna Clemons",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/olivier.jpg",
+       "rating": {
+         "average": 3.1331077,
+         "count": 67
        }
-    },
-    {
-       "brand":"Citroen",
-       "model":"C3",
-       "price_per_day":41,
-       "rating":{
-          "average":4.880431,
-          "count":270
-       },
-       "owner":{
-          "name":"Kasey Ayres",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/19.jpg",
-          "rating":{
-             "average":3.9378479,
-             "count":167
-          }
+     }
+   },
+   {
+     "brand": "Citroen",
+     "model": "C3",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/19.jpg",
+     "price_per_day": 41,
+     "rating": {
+       "average": 4.880431,
+       "count": 270
+     },
+     "owner": {
+       "name": "Kasey Ayres",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/marius.jpg",
+       "rating": {
+         "average": 3.9378479,
+         "count": 167
        }
-    },
-    {
-       "brand":"Citroen",
-       "model":"C4 Grand Picasso",
-       "price_per_day":44,
-       "rating":{
-          "average":4.403592,
-          "count":171
-       },
-       "owner":{
-          "name":"Valeri Kaminski",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/31.jpg",
-          "rating":{
-             "average":4.091597,
-             "count":188
-          }
+     }
+   },
+   {
+     "brand": "Citroen",
+     "model": "C4 Grand Picasso",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/31.jpg",
+     "price_per_day": 44,
+     "rating": {
+       "average": 4.403592,
+       "count": 171
+     },
+     "owner": {
+       "name": "Valeri Kaminski",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/nicolas.jpg",
+       "rating": {
+         "average": 4.091597,
+         "count": 188
        }
-    },
-    {
-       "brand":"Kia",
-       "model":"Picanto",
-       "price_per_day":22,
-       "rating":{
-          "average":4.4706297,
-          "count":186
-       },
-       "owner":{
-          "name":"Rosario Hawley",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/14.jpg",
-          "rating":{
-             "average":4.9118557,
-             "count":200
-          }
+     }
+   },
+   {
+     "brand": "Kia",
+     "model": "Picanto",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/14.jpg",
+     "price_per_day": 22,
+     "rating": {
+       "average": 4.4706297,
+       "count": 186
+     },
+     "owner": {
+       "name": "Rosario Hawley",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/gaetan.jpg",
+       "rating": {
+         "average": 4.9118557,
+         "count": 200
        }
-    },
-    {
-       "brand":"Citroen",
-       "model":"Xsara Picasso",
-       "price_per_day":30,
-       "rating":{
-          "average":4.028204,
-          "count":231
-       },
-       "owner":{
-          "name":"Hai Kuykendall",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/23.jpg",
-          "rating":{
-             "average":3.2815046,
-             "count":16
-          }
+     }
+   },
+   {
+     "brand": "Citroen",
+     "model": "Xsara Picasso",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/23.jpg",
+     "price_per_day": 30,
+     "rating": {
+       "average": 4.028204,
+       "count": 231
+     },
+     "owner": {
+       "name": "Hai Kuykendall",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/perrine.jpg",
+       "rating": {
+         "average": 3.2815046,
+         "count": 16
        }
-    },
-    {
-       "brand":"Fiat",
-       "model":"Punto",
-       "price_per_day":44,
-       "rating":{
-          "average":4.0959406,
-          "count":246
-       },
-       "owner":{
-          "name":"Kenna Clemons",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/24.jpg",
-          "rating":{
-             "average":3.7268405,
-             "count":252
-          }
+     }
+   },
+   {
+     "brand": "Fiat",
+     "model": "Punto",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/24.jpg",
+     "price_per_day": 44,
+     "rating": {
+       "average": 4.0959406,
+       "count": 246
+     },
+     "owner": {
+       "name": "Kenna Clemons",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/olivier.jpg",
+       "rating": {
+         "average": 3.7268405,
+         "count": 252
        }
-    },
-    {
-       "brand":"Citroen",
-       "model":"C3 Picasso",
-       "price_per_day":47,
-       "rating":{
-          "average":3.040584,
-          "count":59
-       },
-       "owner":{
-          "name":"Sylvie Belanger",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/13.jpg",
-          "rating":{
-             "average":4.2138176,
-             "count":177
-          }
+     }
+   },
+   {
+     "brand": "Citroen",
+     "model": "C3 Picasso",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/13.jpg",
+     "price_per_day": 47,
+     "rating": {
+       "average": 3.040584,
+       "count": 59
+     },
+     "owner": {
+       "name": "Sylvie Belanger",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/arnold.jpg",
+       "rating": {
+         "average": 4.2138176,
+         "count": 177
        }
-    },
-    {
-       "brand":"Citroen",
-       "model":"Saxo",
-       "price_per_day":13,
-       "rating":{
-          "average":3.0993094,
-          "count":186
-       },
-       "owner":{
-          "name":"Emmaline Thorne",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/28.jpg",
-          "rating":{
-             "average":4.768528,
-             "count":141
-          }
+     }
+   },
+   {
+     "brand": "Citroen",
+     "model": "Saxo",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/28.jpg",
+     "price_per_day": 13,
+     "rating": {
+       "average": 3.0993094,
+       "count": 186
+     },
+     "owner": {
+       "name": "Emmaline Thorne",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/mathilde.jpg",
+       "rating": {
+         "average": 4.768528,
+         "count": 141
        }
-    },
-    {
-       "brand":"Citroen",
-       "model":"Berlingo Multispace",
-       "price_per_day":21,
-       "rating":{
-          "average":3.4146607,
-          "count":207
-       },
-       "owner":{
-          "name":"Belen Jobe",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/35.jpg",
-          "rating":{
-             "average":3.3969579,
-             "count":101
-          }
+     }
+   },
+   {
+     "brand": "Citroen",
+     "model": "Berlingo Multispace",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/35.jpg",
+     "price_per_day": 21,
+     "rating": {
+       "average": 3.4146607,
+       "count": 207
+     },
+     "owner": {
+       "name": "Belen Jobe",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/paulin.jpg",
+       "rating": {
+         "average": 3.3969579,
+         "count": 101
        }
-    },
-    {
-       "brand":"Kia",
-       "model":"Picanto",
-       "price_per_day":31,
-       "rating":{
-          "average":3.4750695,
-          "count":254
-       },
-       "owner":{
-          "name":"Britni Fitch",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/5.jpg",
-          "rating":{
-             "average":3.5765932,
-             "count":161
-          }
+     }
+   },
+   {
+     "brand": "Kia",
+     "model": "Picanto",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/5.jpg",
+     "price_per_day": 31,
+     "rating": {
+       "average": 3.4750695,
+       "count": 254
+     },
+     "owner": {
+       "name": "Britni Fitch",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/sonia.jpg",
+       "rating": {
+         "average": 3.5765932,
+         "count": 161
        }
-    },
-    {
-       "brand":"Seat",
-       "model":"Ibiza",
-       "price_per_day":34,
-       "rating":{
-          "average":3.8107965,
-          "count":139
-       },
-       "owner":{
-          "name":"Aimee Elliot",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/22.jpg",
-          "rating":{
-             "average":4.4249206,
-             "count":118
-          }
+     }
+   },
+   {
+     "brand": "Seat",
+     "model": "Ibiza",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/22.jpg",
+     "price_per_day": 34,
+     "rating": {
+       "average": 3.8107965,
+       "count": 139
+     },
+     "owner": {
+       "name": "Aimee Elliot",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/jean.jpg",
+       "rating": {
+         "average": 4.4249206,
+         "count": 118
        }
-    },
-    {
-       "brand":"Renault",
-       "model":"Clio",
-       "price_per_day":16,
-       "rating":{
-          "average":3.8758695,
-          "count":210
-       },
-       "owner":{
-          "name":"Emmaline Thorne",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/16.jpg",
-          "rating":{
-             "average":4.620288,
-             "count":82
-          }
+     }
+   },
+   {
+     "brand": "Renault",
+     "model": "Clio",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/16.jpg",
+     "price_per_day": 16,
+     "rating": {
+       "average": 3.8758695,
+       "count": 210
+     },
+     "owner": {
+       "name": "Emmaline Thorne",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/mathilde.jpg",
+       "rating": {
+         "average": 4.620288,
+         "count": 82
        }
-    },
-    {
-       "brand":"Peugeot",
-       "model":"5008",
-       "price_per_day":32,
-       "rating":{
-          "average":3.6854682,
-          "count":135
-       },
-       "owner":{
-          "name":"Allie Savoy",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/34.jpg",
-          "rating":{
-             "average":3.2330704,
-             "count":186
-          }
+     }
+   },
+   {
+     "brand": "Peugeot",
+     "model": "5008",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/34.jpg",
+     "price_per_day": 32,
+     "rating": {
+       "average": 3.6854682,
+       "count": 135
+     },
+     "owner": {
+       "name": "Allie Savoy",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/eloise.jpg",
+       "rating": {
+         "average": 3.2330704,
+         "count": 186
        }
-    },
-    {
-       "brand":"Hyundai",
-       "model":"i20",
-       "price_per_day":18,
-       "rating":{
-          "average":3.751248,
-          "count":30
-       },
-       "owner":{
-          "name":"Claudie Gentry",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/28.jpg",
-          "rating":{
-             "average":3.8033586,
-             "count":246
-          }
+     }
+   },
+   {
+     "brand": "Hyundai",
+     "model": "i20",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/28.jpg",
+     "price_per_day": 18,
+     "rating": {
+       "average": 3.751248,
+       "count": 30
+     },
+     "owner": {
+       "name": "Claudie Gentry",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/kane.jpg",
+       "rating": {
+         "average": 3.8033586,
+         "count": 246
        }
-    },
-    {
-       "brand":"Citroen",
-       "model":"C3",
-       "price_per_day":41,
-       "rating":{
-          "average":4.526775,
-          "count":127
-       },
-       "owner":{
-          "name":"Almeda Valle",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/27.jpg",
-          "rating":{
-             "average":4.6474724,
-             "count":215
-          }
+     }
+   },
+   {
+     "brand": "Citroen",
+     "model": "C3",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/27.jpg",
+     "price_per_day": 41,
+     "rating": {
+       "average": 4.526775,
+       "count": 127
+     },
+     "owner": {
+       "name": "Almeda Valle",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/david.jpg",
+       "rating": {
+         "average": 4.6474724,
+         "count": 215
        }
-    },
-    {
-       "brand":"Citroen",
-       "model":"C2",
-       "price_per_day":35,
-       "rating":{
-          "average":4.5818157,
-          "count":158
-       },
-       "owner":{
-          "name":"Emmaline Thorne",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/34.jpg",
-          "rating":{
-             "average":4.3271832,
-             "count":219
-          }
+     }
+   },
+   {
+     "brand": "Citroen",
+     "model": "C2",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/34.jpg",
+     "price_per_day": 35,
+     "rating": {
+       "average": 4.5818157,
+       "count": 158
+     },
+     "owner": {
+       "name": "Emmaline Thorne",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/mathilde.jpg",
+       "rating": {
+         "average": 4.3271832,
+         "count": 219
        }
-    },
-    {
-       "brand":"Renault",
-       "model":"Scénic",
-       "price_per_day":27,
-       "rating":{
-          "average":4.9011264,
-          "count":83
-       },
-       "owner":{
-          "name":"Deidre Beauchamp",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/27.jpg",
-          "rating":{
-             "average":3.9634335,
-             "count":235
-          }
+     }
+   },
+   {
+     "brand": "Renault",
+     "model": "Scénic",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/27.jpg",
+     "price_per_day": 27,
+     "rating": {
+       "average": 4.9011264,
+       "count": 83
+     },
+     "owner": {
+       "name": "Deidre Beauchamp",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/audrey.jpg",
+       "rating": {
+         "average": 3.9634335,
+         "count": 235
        }
-    },
-    {
-       "brand":"Renault",
-       "model":"Clio",
-       "price_per_day":17,
-       "rating":{
-          "average":4.957422,
-          "count":34
-       },
-       "owner":{
-          "name":"Deidre Beauchamp",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/11.jpg",
-          "rating":{
-             "average":3.0180674,
-             "count":47
-          }
+     }
+   },
+   {
+     "brand": "Renault",
+     "model": "Clio",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/11.jpg",
+     "price_per_day": 17,
+     "rating": {
+       "average": 4.957422,
+       "count": 34
+     },
+     "owner": {
+       "name": "Deidre Beauchamp",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/audrey.jpg",
+       "rating": {
+         "average": 3.0180674,
+         "count": 47
        }
-    },
-    {
-       "brand":"Citroen",
-       "model":"C4 Grand Picasso",
-       "price_per_day":20,
-       "rating":{
-          "average":4.293081,
-          "count":39
-       },
-       "owner":{
-          "name":"Savanna Hough",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/41.jpg",
-          "rating":{
-             "average":4.983462,
-             "count":188
-          }
+     }
+   },
+   {
+     "brand": "Citroen",
+     "model": "C4 Grand Picasso",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/41.jpg",
+     "price_per_day": 20,
+     "rating": {
+       "average": 4.293081,
+       "count": 39
+     },
+     "owner": {
+       "name": "Savanna Hough",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/hugo.jpg",
+       "rating": {
+         "average": 4.983462,
+         "count": 188
        }
-    },
-    {
-       "brand":"Citroen",
-       "model":"Xsara Picasso",
-       "price_per_day":14,
-       "rating":{
-          "average":4.3622823,
-          "count":294
-       },
-       "owner":{
-          "name":"Glady Gipson",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/3.jpg",
-          "rating":{
-             "average":4.0538273,
-             "count":128
-          }
+     }
+   },
+   {
+     "brand": "Citroen",
+     "model": "Xsara Picasso",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/3.jpg",
+     "price_per_day": 14,
+     "rating": {
+       "average": 4.3622823,
+       "count": 294
+     },
+     "owner": {
+       "name": "Glady Gipson",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/kim.jpg",
+       "rating": {
+         "average": 4.0538273,
+         "count": 128
        }
-    },
-    {
-       "brand":"Citroen",
-       "model":"C4 Picasso",
-       "price_per_day":22,
-       "rating":{
-          "average":4.1680274,
-          "count":283
-       },
-       "owner":{
-          "name":"Elmira Sorrell",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/24.jpg",
-          "rating":{
-             "average":3.6744137,
-             "count":288
-          }
+     }
+   },
+   {
+     "brand": "Citroen",
+     "model": "C4 Picasso",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/24.jpg",
+     "price_per_day": 22,
+     "rating": {
+       "average": 4.1680274,
+       "count": 283
+     },
+     "owner": {
+       "name": "Elmira Sorrell",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/howard.jpg",
+       "rating": {
+         "average": 3.6744137,
+         "count": 288
        }
-    },
-    {
-       "brand":"Peugeot",
-       "model":"207",
-       "price_per_day":12,
-       "rating":{
-          "average":4.237507,
-          "count":282
-       },
-       "owner":{
-          "name":"Voncile Hamer",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/13.jpg",
-          "rating":{
-             "average":3.3697057,
-             "count":164
-          }
+     }
+   },
+   {
+     "brand": "Peugeot",
+     "model": "207",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/13.jpg",
+     "price_per_day": 12,
+     "rating": {
+       "average": 4.237507,
+       "count": 282
+     },
+     "owner": {
+       "name": "Voncile Hamer",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/steffen.jpg",
+       "rating": {
+         "average": 3.3697057,
+         "count": 164
        }
-    },
-    {
-       "brand":"Suzuki",
-       "model":"swift",
-       "price_per_day":23,
-       "rating":{
-          "average":3.1800709,
-          "count":247
-       },
-       "owner":{
-          "name":"Eloy Trotter",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/34.jpg",
-          "rating":{
-             "average":4.8846827,
-             "count":225
-          }
+     }
+   },
+   {
+     "brand": "Suzuki",
+     "model": "swift",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/34.jpg",
+     "price_per_day": 23,
+     "rating": {
+       "average": 3.1800709,
+       "count": 247
+     },
+     "owner": {
+       "name": "Eloy Trotter",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/quentin.jpg",
+       "rating": {
+         "average": 4.8846827,
+         "count": 225
        }
-    },
-    {
-       "brand":"Fiat",
-       "model":"Panda",
-       "price_per_day":45,
-       "rating":{
-          "average":3.240968,
-          "count":150
-       },
-       "owner":{
-          "name":"Alica Connell",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/29.jpg",
-          "rating":{
-             "average":4.189346,
-             "count":69
-          }
+     }
+   },
+   {
+     "brand": "Fiat",
+     "model": "Panda",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/29.jpg",
+     "price_per_day": 45,
+     "rating": {
+       "average": 3.240968,
+       "count": 150
+     },
+     "owner": {
+       "name": "Alica Connell",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/emily.jpg",
+       "rating": {
+         "average": 4.189346,
+         "count": 69
        }
-    },
-    {
-       "brand":"Renault",
-       "model":"Clio Campus",
-       "price_per_day":21,
-       "rating":{
-          "average":3.3044863,
-          "count":163
-       },
-       "owner":{
-          "name":"Chelsey Salisbury",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/27.jpg",
-          "rating":{
-             "average":3.5667765,
-             "count":133
-          }
+     }
+   },
+   {
+     "brand": "Renault",
+     "model": "Clio Campus",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/27.jpg",
+     "price_per_day": 21,
+     "rating": {
+       "average": 3.3044863,
+       "count": 163
+     },
+     "owner": {
+       "name": "Chelsey Salisbury",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/nikolai.jpg",
+       "rating": {
+         "average": 3.5667765,
+         "count": 133
        }
-    },
-    {
-       "brand":"Ford",
-       "model":"Fiesta",
-       "price_per_day":47,
-       "rating":{
-          "average":3.3666296,
-          "count":74
-       },
-       "owner":{
-          "name":"Savanna Hough",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/27.jpg",
-          "rating":{
-             "average":3.4965193,
-             "count":153
-          }
+     }
+   },
+   {
+     "brand": "Ford",
+     "model": "Fiesta",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/27.jpg",
+     "price_per_day": 47,
+     "rating": {
+       "average": 3.3666296,
+       "count": 74
+     },
+     "owner": {
+       "name": "Savanna Hough",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/hugo.jpg",
+       "rating": {
+         "average": 3.4965193,
+         "count": 153
        }
-    },
-    {
-       "brand":"Suzuki",
-       "model":"swift",
-       "price_per_day":42,
-       "rating":{
-          "average":3.8898582,
-          "count":63
-       },
-       "owner":{
-          "name":"Cassy Burnette",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/3.jpg",
-          "rating":{
-             "average":4.5329566,
-             "count":190
-          }
+     }
+   },
+   {
+     "brand": "Suzuki",
+     "model": "swift",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/3.jpg",
+     "price_per_day": 42,
+     "rating": {
+       "average": 3.8898582,
+       "count": 63
+     },
+     "owner": {
+       "name": "Cassy Burnette",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/marc.jpg",
+       "rating": {
+         "average": 4.5329566,
+         "count": 190
        }
-    },
-    {
-       "brand":"Fiat",
-       "model":"Punto",
-       "price_per_day":32,
-       "rating":{
-          "average":3.9531965,
-          "count":46
-       },
-       "owner":{
-          "name":"Britni Fitch",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/24.jpg",
-          "rating":{
-             "average":4.478217,
-             "count":130
-          }
+     }
+   },
+   {
+     "brand": "Fiat",
+     "model": "Punto",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/24.jpg",
+     "price_per_day": 32,
+     "rating": {
+       "average": 3.9531965,
+       "count": 46
+     },
+     "owner": {
+       "name": "Britni Fitch",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/sonia.jpg",
+       "rating": {
+         "average": 4.478217,
+         "count": 130
        }
-    },
-    {
-       "brand":"Ford",
-       "model":"C-Max",
-       "price_per_day":32,
-       "rating":{
-          "average":3.5146246,
-          "count":243
-       },
-       "owner":{
-          "name":"Almeda Valle",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/36.jpg",
-          "rating":{
-             "average":3.840045,
-             "count":50
-          }
+     }
+   },
+   {
+     "brand": "Ford",
+     "model": "C-Max",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/36.jpg",
+     "price_per_day": 32,
+     "rating": {
+       "average": 3.5146246,
+       "count": 243
+     },
+     "owner": {
+       "name": "Almeda Valle",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/david.jpg",
+       "rating": {
+         "average": 3.840045,
+         "count": 50
        }
-    },
-    {
-       "brand":"Citroen",
-       "model":"C3 Picasso",
-       "price_per_day":26,
-       "rating":{
-          "average":3.5782325,
-          "count":90
-       },
-       "owner":{
-          "name":"Emmaline Thorne",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/7.jpg",
-          "rating":{
-             "average":3.1603808,
-             "count":270
-          }
+     }
+   },
+   {
+     "brand": "Citroen",
+     "model": "C3 Picasso",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/7.jpg",
+     "price_per_day": 26,
+     "rating": {
+       "average": 3.5782325,
+       "count": 90
+     },
+     "owner": {
+       "name": "Emmaline Thorne",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/mathilde.jpg",
+       "rating": {
+         "average": 3.1603808,
+         "count": 270
        }
-    },
-    {
-       "brand":"Kia",
-       "model":"Picanto",
-       "price_per_day":26,
-       "rating":{
-          "average":3.029051,
-          "count":6
-       },
-       "owner":{
-          "name":"Cammie Sells",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/32.jpg",
-          "rating":{
-             "average":4.681478,
-             "count":178
-          }
+     }
+   },
+   {
+     "brand": "Kia",
+     "model": "Picanto",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/32.jpg",
+     "price_per_day": 26,
+     "rating": {
+       "average": 3.029051,
+       "count": 6
+     },
+     "owner": {
+       "name": "Cammie Sells",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/isabelle.jpg",
+       "rating": {
+         "average": 4.681478,
+         "count": 178
        }
-    },
-    {
-       "brand":"Renault",
-       "model":"Espace",
-       "price_per_day":40,
-       "rating":{
-          "average":3.0950751,
-          "count":119
-       },
-       "owner":{
-          "name":"Elmira Sorrell",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/28.jpg",
-          "rating":{
-             "average":4.36119,
-             "count":158
-          }
+     }
+   },
+   {
+     "brand": "Renault",
+     "model": "Espace",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/28.jpg",
+     "price_per_day": 40,
+     "rating": {
+       "average": 3.0950751,
+       "count": 119
+     },
+     "owner": {
+       "name": "Elmira Sorrell",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/howard.jpg",
+       "rating": {
+         "average": 4.36119,
+         "count": 158
        }
-    },
-    {
-       "brand":"Renault",
-       "model":"Clio Campus",
-       "price_per_day":16,
-       "rating":{
-          "average":3.4047322,
-          "count":42
-       },
-       "owner":{
-          "name":"Pearline Pate",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/39.jpg",
-          "rating":{
-             "average":3.9886503,
-             "count":126
-          }
+     }
+   },
+   {
+     "brand": "Renault",
+     "model": "Clio Campus",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/39.jpg",
+     "price_per_day": 16,
+     "rating": {
+       "average": 3.4047322,
+       "count": 42
+     },
+     "owner": {
+       "name": "Pearline Pate",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/robert.jpg",
+       "rating": {
+         "average": 3.9886503,
+         "count": 126
        }
-    },
-    {
-       "brand":"Volkswagen",
-       "model":"Polo",
-       "price_per_day":18,
-       "rating":{
-          "average":3.469561,
-          "count":211
-       },
-       "owner":{
-          "name":"Long Gann",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/8.jpg",
-          "rating":{
-             "average":3.0432847,
-             "count":242
-          }
+     }
+   },
+   {
+     "brand": "Volkswagen",
+     "model": "Polo",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/8.jpg",
+     "price_per_day": 18,
+     "rating": {
+       "average": 3.469561,
+       "count": 211
+     },
+     "owner": {
+       "name": "Long Gann",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/sandra.jpg",
+       "rating": {
+         "average": 3.0432847,
+         "count": 242
        }
-    },
-    {
-       "brand":"Citroen",
-       "model":"C4 Picasso",
-       "price_per_day":31,
-       "rating":{
-          "average":3.821343,
-          "count":182
-       },
-       "owner":{
-          "name":"Ninfa Harkins",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/11.jpg",
-          "rating":{
-             "average":4.9548464,
-             "count":189
-          }
+     }
+   },
+   {
+     "brand": "Citroen",
+     "model": "C4 Picasso",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/11.jpg",
+     "price_per_day": 31,
+     "rating": {
+       "average": 3.821343,
+       "count": 182
+     },
+     "owner": {
+       "name": "Ninfa Harkins",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/alexandru.jpg",
+       "rating": {
+         "average": 4.9548464,
+         "count": 189
        }
-    },
-    {
-       "brand":"Citroen",
-       "model":"C4 Grand Picasso",
-       "price_per_day":29,
-       "rating":{
-          "average":3.881019,
-          "count":95
-       },
-       "owner":{
-          "name":"Andre Jack",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/1.jpg",
-          "rating":{
-             "average":4.025211,
-             "count":25
-          }
+     }
+   },
+   {
+     "brand": "Citroen",
+     "model": "C4 Grand Picasso",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/1.jpg",
+     "price_per_day": 29,
+     "rating": {
+       "average": 3.881019,
+       "count": 95
+     },
+     "owner": {
+       "name": "Andre Jack",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/guillemette.jpg",
+       "rating": {
+         "average": 4.025211,
+         "count": 25
        }
-    },
-    {
-       "brand":"Volkswagen",
-       "model":"Touran",
-       "price_per_day":13,
-       "rating":{
-          "average":3.696429,
-          "count":50
-       },
-       "owner":{
-          "name":"Kasey Ayres",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/26.jpg",
-          "rating":{
-             "average":3.6370091,
-             "count":137
-          }
+     }
+   },
+   {
+     "brand": "Volkswagen",
+     "model": "Touran",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/26.jpg",
+     "price_per_day": 13,
+     "rating": {
+       "average": 3.696429,
+       "count": 50
+     },
+     "owner": {
+       "name": "Kasey Ayres",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/marius.jpg",
+       "rating": {
+         "average": 3.6370091,
+         "count": 137
        }
-    },
-    {
-       "brand":"Peugeot",
-       "model":"208",
-       "price_per_day":39,
-       "rating":{
-          "average":3.7558866,
-          "count":163
-       },
-       "owner":{
-          "name":"Glady Gipson",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/39.jpg",
-          "rating":{
-             "average":3.3323002,
-             "count":101
-          }
+     }
+   },
+   {
+     "brand": "Peugeot",
+     "model": "208",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/39.jpg",
+     "price_per_day": 39,
+     "rating": {
+       "average": 3.7558866,
+       "count": 163
+     },
+     "owner": {
+       "name": "Glady Gipson",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/kim.jpg",
+       "rating": {
+         "average": 3.3323002,
+         "count": 101
        }
-    },
-    {
-       "brand":"Peugeot",
-       "model":"207",
-       "price_per_day":36,
-       "rating":{
-          "average":4.684417,
-          "count":166
-       },
-       "owner":{
-          "name":"Ressie Perrin",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/20.jpg",
-          "rating":{
-             "average":4.850573,
-             "count":272
-          }
+     }
+   },
+   {
+     "brand": "Peugeot",
+     "model": "207",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/20.jpg",
+     "price_per_day": 36,
+     "rating": {
+       "average": 4.684417,
+       "count": 166
+     },
+     "owner": {
+       "name": "Ressie Perrin",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/alba.jpg",
+       "rating": {
+         "average": 4.850573,
+         "count": 272
        }
-    },
-    {
-       "brand":"Renault",
-       "model":"Scénic",
-       "price_per_day":38,
-       "rating":{
-          "average":4.7523975,
-          "count":183
-       },
-       "owner":{
-          "name":"Tory Sanborn",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/39.jpg",
-          "rating":{
-             "average":4.155237,
-             "count":156
-          }
+     }
+   },
+   {
+     "brand": "Renault",
+     "model": "Scénic",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/39.jpg",
+     "price_per_day": 38,
+     "rating": {
+       "average": 4.7523975,
+       "count": 183
+     },
+     "owner": {
+       "name": "Tory Sanborn",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/tim.jpg",
+       "rating": {
+         "average": 4.155237,
+         "count": 156
        }
-    },
-    {
-       "brand":"Renault",
-       "model":"Modus",
-       "price_per_day":30,
-       "rating":{
-          "average":4.8099136,
-          "count":162
-       },
-       "owner":{
-          "name":"Alica Connell",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/14.jpg",
-          "rating":{
-             "average":3.5414562,
-             "count":84
-          }
+     }
+   },
+   {
+     "brand": "Renault",
+     "model": "Modus",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/14.jpg",
+     "price_per_day": 30,
+     "rating": {
+       "average": 4.8099136,
+       "count": 162
+     },
+     "owner": {
+       "name": "Alica Connell",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/emily.jpg",
+       "rating": {
+         "average": 3.5414562,
+         "count": 84
        }
-    },
-    {
-       "brand":"Citroen",
-       "model":"Berlingo Multispace",
-       "price_per_day":44,
-       "rating":{
-          "average":4.876707,
-          "count":27
-       },
-       "owner":{
-          "name":"Eloy Trotter",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/1.jpg",
-          "rating":{
-             "average":3.4711993,
-             "count":80
-          }
+     }
+   },
+   {
+     "brand": "Citroen",
+     "model": "Berlingo Multispace",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/1.jpg",
+     "price_per_day": 44,
+     "rating": {
+       "average": 4.876707,
+       "count": 27
+     },
+     "owner": {
+       "name": "Eloy Trotter",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/quentin.jpg",
+       "rating": {
+         "average": 3.4711993,
+         "count": 80
        }
-    },
-    {
-       "brand":"Fiat",
-       "model":"Punto",
-       "price_per_day":17,
-       "rating":{
-          "average":4.4160395,
-          "count":166
-       },
-       "owner":{
-          "name":"Porsha Schmitz",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/24.jpg",
-          "rating":{
-             "average":4.561714,
-             "count":275
-          }
+     }
+   },
+   {
+     "brand": "Fiat",
+     "model": "Punto",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/24.jpg",
+     "price_per_day": 17,
+     "rating": {
+       "average": 4.4160395,
+       "count": 166
+     },
+     "owner": {
+       "name": "Porsha Schmitz",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/raphael.jpg",
+       "rating": {
+         "average": 4.561714,
+         "count": 275
        }
-    },
-    {
-       "brand":"Hyundai",
-       "model":"i20",
-       "price_per_day":11,
-       "rating":{
-          "average":4.4737663,
-          "count":71
-       },
-       "owner":{
-          "name":"Harriett Hoy",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/30.jpg",
-          "rating":{
-             "average":4.5069737,
-             "count":175
-          }
+     }
+   },
+   {
+     "brand": "Hyundai",
+     "model": "i20",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/30.jpg",
+     "price_per_day": 11,
+     "rating": {
+       "average": 4.4737663,
+       "count": 71
+     },
+     "owner": {
+       "name": "Harriett Hoy",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/pierre.jpg",
+       "rating": {
+         "average": 4.5069737,
+         "count": 175
        }
-    },
-    {
-       "brand":"Citroen",
-       "model":"C4 Picasso",
-       "price_per_day":27,
-       "rating":{
-          "average":4.0411854,
-          "count":266
-       },
-       "owner":{
-          "name":"Hilma Krieger",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/33.jpg",
-          "rating":{
-             "average":3.8775916,
-             "count":255
-          }
+     }
+   },
+   {
+     "brand": "Citroen",
+     "model": "C4 Picasso",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/33.jpg",
+     "price_per_day": 27,
+     "rating": {
+       "average": 4.0411854,
+       "count": 266
+     },
+     "owner": {
+       "name": "Hilma Krieger",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/diane.jpg",
+       "rating": {
+         "average": 3.8775916,
+         "count": 255
        }
-    },
-    {
-       "brand":"Fiat",
-       "model":"Panda",
-       "price_per_day":33,
-       "rating":{
-          "average":4.0987015,
-          "count":195
-       },
-       "owner":{
-          "name":"Sonny Durant",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/34.jpg",
-          "rating":{
-             "average":3.1979265,
-             "count":235
-          }
+     }
+   },
+   {
+     "brand": "Fiat",
+     "model": "Panda",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/34.jpg",
+     "price_per_day": 33,
+     "rating": {
+       "average": 4.0987015,
+       "count": 195
+     },
+     "owner": {
+       "name": "Sonny Durant",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/gwenaelle.jpg",
+       "rating": {
+         "average": 3.1979265,
+         "count": 235
        }
-    },
-    {
-       "brand":"Suzuki",
-       "model":"swift",
-       "price_per_day":34,
-       "rating":{
-          "average":3.1705856,
-          "count":146
-       },
-       "owner":{
-          "name":"Darrick Luther",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/6.jpg",
-          "rating":{
-             "average":4.2920465,
-             "count":154
-          }
+     }
+   },
+   {
+     "brand": "Suzuki",
+     "model": "swift",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/6.jpg",
+     "price_per_day": 34,
+     "rating": {
+       "average": 3.1705856,
+       "count": 146
+     },
+     "owner": {
+       "name": "Darrick Luther",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/jack.jpg",
+       "rating": {
+         "average": 4.2920465,
+         "count": 154
        }
-    },
-    {
-       "brand":"Citroen",
-       "model":"Saxo",
-       "price_per_day":40,
-       "rating":{
-          "average":3.2349262,
-          "count":243
-       },
-       "owner":{
-          "name":"Porsha Schmitz",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/20.jpg",
-          "rating":{
-             "average":4.721713,
-             "count":222
-          }
+     }
+   },
+   {
+     "brand": "Citroen",
+     "model": "Saxo",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/20.jpg",
+     "price_per_day": 40,
+     "rating": {
+       "average": 3.2349262,
+       "count": 243
+     },
+     "owner": {
+       "name": "Porsha Schmitz",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/raphael.jpg",
+       "rating": {
+         "average": 4.721713,
+         "count": 222
        }
-    },
-    {
-       "brand":"Ford",
-       "model":"C-Max",
-       "price_per_day":32,
-       "rating":{
-          "average":3.2964163,
-          "count":94
-       },
-       "owner":{
-          "name":"Eloy Trotter",
-          "picture_url":"https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/37.jpg",
-          "rating":{
-             "average":3.1001127,
-             "count":174
-          }
+     }
+   },
+   {
+     "brand": "Ford",
+     "model": "C-Max",
+     "picture_url": "https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/37.jpg",
+     "price_per_day": 32,
+     "rating": {
+       "average": 3.2964163,
+       "count": 94
+     },
+     "owner": {
+       "name": "Eloy Trotter",
+       "picture_url": "https://drivy-assets.imgix.net/jobs/team/quentin.jpg",
+       "rating": {
+         "average": 3.1001127,
+         "count": 174
        }
-    }
+     }
+   }
  ]


### PR DESCRIPTION
Fix cars.json regression since https://github.com/drivy/jobs/pull/50

Missing owners photos
Car picture link to the right repository  `Jobs` instead of `mobile-technical-test`
`https://github.com/drivy/mobile-technical-test/raw/master/api/pictures/13.jpg` -> `https://raw.githubusercontent.com/drivy/jobs/master/mobile/api/pictures/13.jpg`