### PR TITLE
fix: deprecated urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ have to complete one of our code challenges:
 - [Data Science](https://github.com/drivy/jobs/tree/master/data_science)
 
 In order to learn more about [Getaround](https://www.getaround.com/),
-you can head over our [engineering blog](https://drivy.engineering/)
+you can head over our [engineering blog](https://getaround.tech/)
 or check out [the currently open positions](https://uk.getaround.com/jobs).

--- a/analytics_engineering/README.md
+++ b/analytics_engineering/README.md
@@ -1,7 +1,7 @@
 # Getaround EU Analytics Engineering Challenge (previously Drivy)
 
 Looking for a job? Check out our [open positions](https://www.welcometothejungle.com/en/companies/getaround/jobs).
-You can also take a look at our [engineering blog](https://drivy.engineering/) to learn more about the way we work.
+You can also take a look at our [engineering blog](https://getaround.tech/) to learn more about the way we work.
 
 ## General guidelines
 

--- a/analytics_engineering_internship/README.md
+++ b/analytics_engineering_internship/README.md
@@ -1,7 +1,7 @@
 # Getaround EU Analytics Engineering Challenge (previously Drivy)
 
 Looking for a job? Check out our [open positions](https://www.welcometothejungle.com/en/companies/getaround/jobs).
-You can also take a look at our [engineering blog](https://drivy.engineering/) to learn more about the way we work.
+You can also take a look at our [engineering blog](https://getaround.tech/) to learn more about the way we work.
 
 
 ## General guidelines

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,7 +1,7 @@
 # Getaround EU Backend Challenge (previously Drivy)
 
-Looking for a job? Check out our [open positions](https://uk.getaround.com.com/jobs).
-You can also take a look at our [engineering blog](https://drivy.engineering/) to learn more about the way we work.
+Looking for a job? Check out our [open positions](https://getaround.com/careers).
+You can also take a look at our [engineering blog](https://getaround.tech/) to learn more about the way we work.
 
 ## Guidelines
 
@@ -19,7 +19,7 @@ You can have a look at the higher levels, but please do the simplest thing that 
 The levels become more complex over time, so you will probably have to re-use some code and adapt it to the new requirements.
 A good way to solve this is by using OOP, adding new layers of abstraction when they become necessary and possibly write tests so you don't break what you have already done.
 
-Don't hesitate to write [shameless code](http://red-badger.com/blog/2014/08/20/i-spent-3-days-with-sandi-metz-heres-what-i-learned/) at first, and then refactor it in the next levels.
+Don't hesitate to write [shameless code](https://www.jackhoy.com/web-applications/2014/08/20/i-spent-3-days-with-sandi-metz-heres-what-i-learned.html) at first, and then refactor it in the next levels.
 
 For higher levels we are interested in seeing code that is clean, extensible and robust, so don't overlook edge cases, use exceptions where needed, ...
 
@@ -33,7 +33,7 @@ Please also note that:
 Once you are done, please send your results to someone from Getaround.
 
 - If you are already in discussion with us, send it directly to the person you are talking to.
-- If not, use the application form [on every job listing](https://en.drivy.com/jobs).
+- If not, use the application form [on every job listing](https://getaround.com/careers).
 
 You can send your Github project link or zip your directory and send it via email.
 If you do not use Github, don't forget to attach your `.git` folder.

--- a/data/README.md
+++ b/data/README.md
@@ -1,7 +1,7 @@
 # Getaround EU Data Engineering Challenge (previously Drivy)
 
-Looking for a job? Check out our [open positions](https://uk.getaround.com.com/jobs).
-You can also take a look at our [engineering blog](https://drivy.engineering/) to learn more about the way we work.
+Looking for a job? Check out our [open positions](https://getaround.com/careers).
+You can also take a look at our [engineering blog](https://getaround.tech/) to learn more about the way we work.
 
 
 ## Guidelines

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,7 +1,7 @@
 # Getaround EU Frontend Challenge (previously Drivy)
 
-Looking for a job? Check out our [open positions](https://uk.getaround.com.com/jobs).
-You can also take a look at our [engineering blog](https://drivy.engineering/) to learn more about the way we work.
+Looking for a job? Check out our [open positions](https://getaround.com/careers).
+You can also take a look at our [engineering blog](https://getaround.tech/) to learn more about the way we work.
 
 ## Guidelines
 
@@ -31,7 +31,7 @@ This test is framework agnostic, feel free to stick to vanilla HTML/JS/CSS or go
 Once you are done, please send your results to someone from Getaround.
 
 - If you are already in discussion with us, send it directly to the person you are talking to.
-- If not, use the application form [on every job listing](https://en.drivy.com/jobs).
+- If not, use the application form [on every job listing](https://getaround.com/careers).
 
 You can send your Github project link or zip your directory and send it via email.
 If you do not use Github, don't forget to attach your `.git` folder.

--- a/reliability/README.md
+++ b/reliability/README.md
@@ -1,7 +1,7 @@
 # Getaround EU Reliability Challenge (previously Drivy)
 
-Looking for a job? Check out our [open positions](https://uk.getaround.com.com/jobs).
-You can also take a look at our [engineering blog](https://drivy.engineering/) to learn more about the way we work.
+Looking for a job? Check out our [open positions](https://getaround.com/careers).
+You can also take a look at our [engineering blog](https://getaround.tech/) to learn more about the way we work.
 
 ## Guidelines
 
@@ -16,7 +16,7 @@ You can have a look at the higher levels, but please do the simplest thing that 
 The levels become more complex over time, so you will probably have to re-use some code and adapt it to the new requirements.
 A good way to solve this is by using OOP, adding new layers of abstraction when they become necessary and possibly write tests so you don't break what you have already done.
 
-Don't hesitate to write [shameless code](http://red-badger.com/blog/2014/08/20/i-spent-3-days-with-sandi-metz-heres-what-i-learned/) at first, and then refactor it in the next levels.
+Don't hesitate to write [shameless code](https://www.jackhoy.com/web-applications/2014/08/20/i-spent-3-days-with-sandi-metz-heres-what-i-learned.html) at first, and then refactor it in the next levels.
 
 For higher levels we are interested in seeing code that is clean, extensible and robust, so don't overlook edge cases, use exceptions where needed, ...
 
@@ -31,7 +31,7 @@ Please also note that:
 Once you are done, please send your results to someone at Getaround.
 
 - If you are already in discussion with us, send it directly to the person you are talking to.
-- If not, use the application form [on every job listing](https://en.drivy.com/jobs).
+- If not, use the application form [on every job listing](https://getaround.com/careers).
 
 You can send your Github project link or zip your directory and send it via email.
 If you do not use Github, don't forget to attach your `.git` folder.


### PR DESCRIPTION
Fix broken and deprecated urls.

Example: `https://uk.getaround.com.com/jobs` -> `https://getaround.com/careers`

@jeanelie 